### PR TITLE
Fix regression in IpV4Packet.newPacket catch clause

### DIFF
--- a/app/src/main/java/org/jak_linux/dns66/vpn/AdVpnThread.java
+++ b/app/src/main/java/org/jak_linux/dns66/vpn/AdVpnThread.java
@@ -312,7 +312,7 @@ class AdVpnThread implements Runnable {
         IpV4Packet parsedPacket = null;
         try {
             parsedPacket = IpV4Packet.newPacket(packet, 0, packet.length);
-        } catch (IllegalRawDataException e) {
+        } catch (Exception e) {
             Log.i(TAG, "handleDnsRequest: Discarding invalid IPv4 packet", e);
             return;
         }


### PR DESCRIPTION
The function may throw other RuntimeExceptions like IllegalArgument
that we did not check for.

This fixes a regression introduced in:

commit f1c0bf8b3f6ee939d413abb4013359ac95222e95

    AdVpnThread.handleDnsRequest: More localized exception handling